### PR TITLE
Include CROSS_COMPILE in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 fbkeyboard: fbkeyboard.c
-	gcc -o fbkeyboard $(shell freetype-config --cflags) $(shell freetype-config --libs) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) fbkeyboard.c
+	$(CROSS_COMPILE)gcc -o fbkeyboard $(shell freetype-config --cflags) $(shell freetype-config --libs) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) fbkeyboard.c
 
 clean:
 	rm -f fbkeyboard


### PR DESCRIPTION
This way the program can be easily cross-compiled for foreign architectures from source.